### PR TITLE
bug: image 용량 크기 제한 오류

### DIFF
--- a/TecheerPicture/docker-compose.yml
+++ b/TecheerPicture/docker-compose.yml
@@ -43,6 +43,10 @@ services:
     depends_on: # Flyway 마이그레이션 후 실행
       - db
       - flyway
+    environment:
+      - SPRING_SERVLET_MULTIPART_ENABLED=true
+      - SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE=25MB
+      - SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE=25MB
 
 volumes:
   db_data:


### PR DESCRIPTION
image 업로드 시 1MB 이상 이미지가 업로드 되지 않는 오류
-> background 생성 시 최대 사이즈인 25MB까지 업로드 허용
(1) swagger 업로드 성공 예시
![image](https://github.com/user-attachments/assets/77187add-31b4-45ba-8ee8-a0c7f8a0f18a)
(2) s3 에서 1MB이상 이미지 업로드 성공 화면
![image](https://github.com/user-attachments/assets/578b151b-0c8b-4d8a-a046-6dbd74e92eec)

