### PR TITLE
feat: Banner 이미지 분석 기능 추가

### DIFF
--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/external/GPTService.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/external/GPTService.java
@@ -32,7 +32,7 @@ public class GPTService {
    * @param addInformation 추가 정보
    * @return GeneratedTexts 생성된 광고 문구를 담은 객체
    */
-  public GeneratedTexts generateAdTexts(String itemName, String itemConcept, String itemCategory, String addInformation) {
+  public GeneratedTexts generateAdTexts(String itemName, String itemConcept, String itemCategory, String addInformation, String imageUrl) {
     String apiUrl = "https://api.openai.com/v1/chat/completions";
 
     // GPT 요청 프롬프트 작성
@@ -42,6 +42,8 @@ public class GPTService {
             "컨셉: '%s'\n" +
             "카테고리: '%s'\n" +
             "추가 정보: '%s'\n\n" +
+            "이 이미지url 을 분석해주세요. : '%s'\n\n" +
+            "이미지 분위기를 제품 정보에 추가적으로  반영하여 광고 문구를 생성하세요.\n" +
             "각 광고는 메인 문장(maintext)과 서브 문장(servtext)로 구성됩니다.\n" +
             "출력 형식:\n" +
             "- 세트 1:\n" +
@@ -50,12 +52,12 @@ public class GPTService {
             "- 세트 2:\n" +
             "  메인 문장: [maintext2]\n" +
             "  서브 문장: [servtext2]",
-        itemName, itemConcept, itemCategory, addInformation
+        itemName, itemConcept, itemCategory, addInformation,imageUrl
     );
 
     // 요청 본문 생성
     Map<String, Object> requestBody = Map.of(
-        "model", "gpt-3.5-turbo",
+        "model", "gpt-4o",
         "messages", List.of(
             Map.of("role", "system", "content", "You are a helpful assistant."),
             Map.of("role", "user", "content", prompt)

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/service/BannerService.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/service/BannerService.java
@@ -11,6 +11,7 @@ import com.techeerpicture.TecheerPicture.Banner.entity.Banner;
 import com.techeerpicture.TecheerPicture.Banner.external.GPTService;
 import com.techeerpicture.TecheerPicture.Banner.util.GeneratedTexts;
 
+
 @Service
 public class BannerService {
 
@@ -28,12 +29,15 @@ public class BannerService {
     Image image = imageRepository.findById(request.getImageId())
         .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
 
+
+    String imageUrl = image.getImageUrl();
     // GPT를 이용해 광고 문구 생성
     GeneratedTexts texts = gptService.generateAdTexts(
         request.getItemName(),
         request.getItemConcept(),
         request.getItemCategory(),
-        request.getAddInformation()
+        request.getAddInformation(),
+        imageUrl
     );
 
     // Banner 객체 생성 및 값 설정
@@ -45,7 +49,7 @@ public class BannerService {
     banner.setItemName(request.getItemName());
     banner.setItemConcept(request.getItemConcept());
     banner.setItemCategory(request.getItemCategory());
-    banner.setPrompt(request.getAddInformation()); // ✅ add_information을 prompt로 저장
+    banner.setPrompt(request.getAddInformation()); //add_information을 prompt로 저장
     banner.setImage(image); // Image 설정
 
     return bannerRepository.save(banner);
@@ -62,12 +66,14 @@ public class BannerService {
       Image image = imageRepository.findById(request.getImageId())
           .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
 
+      String imageUrl = image.getImageUrl();
       // GPT를 이용해 광고 문구 재생성
       GeneratedTexts texts = gptService.generateAdTexts(
           request.getItemName(),
           request.getItemConcept(),
           request.getItemCategory(),
-          request.getAddInformation()
+          request.getAddInformation(),
+          imageUrl
       );
 
       // Banner 객체 업데이트
@@ -78,7 +84,7 @@ public class BannerService {
       banner.setItemName(request.getItemName());
       banner.setItemConcept(request.getItemConcept());
       banner.setItemCategory(request.getItemCategory());
-      banner.setPrompt(request.getAddInformation()); // ✅ add_information을 prompt로 저장
+      banner.setPrompt(request.getAddInformation()); //add_information을 prompt로 저장
       banner.setImage(image); // Image 업데이트
 
       return bannerRepository.save(banner);


### PR DESCRIPTION
기존 imageanalysis의 이미지 분석 기능을 Banner에 병합. 이미지가 베너 문구 생성에 관여하도록 구현

(1) request body
기존 request body에 imageid 추가
![image](https://github.com/user-attachments/assets/f587d83f-7a32-4be3-8b84-8f018cb97e7d)

(2)response body
[201]
![image](https://github.com/user-attachments/assets/181b299b-be57-4a18-ac9f-85ca4fe164a7)
[500]
imageid 요청이 올바르지 않을 시
![image](https://github.com/user-attachments/assets/ce11492c-3ce7-4b5e-b78e-d840af07e56e)

(3) gpt 요청 prompt
![image](https://github.com/user-attachments/assets/5772a807-2648-4ecd-856b-183ebc5e1a44)
