### PR TITLE
refactor : GPT 광고 문구 생성에 비동기 처리 적용 (CompletableFuture + @Async)

### DIFF
--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/external/GPTService.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/external/GPTService.java
@@ -1,5 +1,6 @@
 package com.techeerpicture.TecheerPicture.Banner.external;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -9,6 +10,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import com.techeerpicture.TecheerPicture.Banner.util.GeneratedTexts;
 /**
@@ -102,7 +104,14 @@ public class GPTService {
       throw new RuntimeException("GPT 호출 실패: " + e.getMessage(), e);
     }
   }
-
+  @Async
+  public CompletableFuture<GeneratedTexts> generateAdTextsAsync(
+      String itemName, String itemConcept, String itemCategory,
+      String addInformation, String imageUrl
+  ) {
+    GeneratedTexts texts = generateAdTexts(itemName, itemConcept, itemCategory, addInformation, imageUrl);
+    return CompletableFuture.completedFuture(texts);
+  }
   /**
    * 생성된 텍스트를 파싱하여 광고 문구를 추출하는 메서드
    *

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/TecheerPictureApplication.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/TecheerPictureApplication.java
@@ -3,8 +3,10 @@ package com.techeerpicture.TecheerPicture;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync  // 비동기 처리 활성화
 @ComponentScan(basePackages = "com.techeerpicture")
 public class TecheerPictureApplication {
 	public static void main(String[] args) {


### PR DESCRIPTION
## 주요 변경 사항

- GPTService에 @Async 적용
  - generateAdTextsAsync 메서드 추가 (기존 동기 메서드 래핑)
- BannerService 내에서 GPT 호출을 CompletableFuture 기반으로 처리
  - `.join()`으로 결과를 대기하지만, 향후 개선 여지 확보
- TecheerPictureApplication에 @EnableAsync 추가로 비동기 활성화

## 성능 테스트 결과 (k6)

- 평균 응답 시간: 3.55초 → 1.76초로 약 50.4% 더 빨라짐
- 처리량(TPS): 2.06 req/s → 3.52 req/s
- 총 요청 처리 건수: 70건 → 114건
- 실패율: 0%

## 향후 개선 방향

- 병렬 처리 구조 적용 가능 (`CompletableFuture.allOf`, `thenApply`)
- GPT 응답 캐싱 고려 (`@Cacheable` 등)
- 응답 파싱 성능 고도화 및 오류 처리 개선

## 테스트
![image](https://github.com/user-attachments/assets/d9a0802a-8adf-44a9-8b1e-98745446cb67)

- k6 부하 테스트로 성능 개선 확인 완료
- 200 응답률 100% 유지
