### PR TITLE
refactor : thenApply + allOf 기반 병렬 처리 구조 도입 (배너 대량 생성 API 최적화)

### DIFF
--- a/TecheerPicture/docker-compose.yml
+++ b/TecheerPicture/docker-compose.yml
@@ -59,8 +59,8 @@ services:
     image: grafana/k6
     container_name: k6-load-test
     volumes:
-      - ./k6-test.js:/k6-test.js
-    command: ["run", "/k6-test.js"]
+      - ./k6-tests:/k6-tests
+    entrypoint: [ "/bin/sh", "-c", "if [ \"$K6_ENABLED\" = \"true\" ]; then k6 run /k6-tests/${K6_SCRIPT}; else echo 'K6 disabled'; fi" ]
     depends_on:
       backend:
         condition: service_healthy

--- a/TecheerPicture/k6-tests/bulk-banner-test.js
+++ b/TecheerPicture/k6-tests/bulk-banner-test.js
@@ -1,0 +1,57 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    vus: 10,             // 동시 사용자 수
+    duration: '30s'      // 테스트 시간
+};
+
+const BASE_URL = 'http://spring-boot-app:8080'; // Docker 내 컨테이너 이름 사용
+
+export default function () {
+    testBulkBannerAPI();
+    sleep(1);
+}
+
+function testBulkBannerAPI() {
+    const url = `${BASE_URL}/api/v1/banners/collection`;
+
+    const payload = JSON.stringify({
+        requests: [
+            {
+                itemName: "선크림",
+                itemConcept: "자연스러운",
+                itemCategory: "화장품",
+                addInformation: "봄 한정",
+                imageId: 2
+            },
+            {
+                itemName: "립밤",
+                itemConcept: "매트한",
+                itemCategory: "화장품",
+                addInformation: "1+1 이벤트",
+                imageId: 2
+            },
+            {
+                itemName: "마스크팩",
+                itemConcept: "진정 케어",
+                itemCategory: "화장품",
+                addInformation: "피부 자극 최소화",
+                imageId: 2
+            }
+        ]
+    });
+
+    const params = {
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+
+    const res = http.post(url, payload, params);
+
+    check(res, {
+        '배너 bulk API 응답 상태가 201인가?': (r) => r.status === 201,
+        '응답에 배열 데이터가 포함되어 있는가?': (r) => r.body.includes('[')
+    });
+}

--- a/TecheerPicture/k6-tests/single-banner-test.js
+++ b/TecheerPicture/k6-tests/single-banner-test.js
@@ -1,3 +1,4 @@
+
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 
@@ -36,3 +37,4 @@ function testBannerAPI() {
         'Banner API 응답 상태가 200인가?': (r) => r.status === 200 || r.status === 201
     });
 }
+

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/dto/BannerBulkRequest.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/dto/BannerBulkRequest.java
@@ -1,0 +1,15 @@
+package com.techeerpicture.TecheerPicture.Banner.dto;
+
+import java.util.List;
+
+public class BannerBulkRequest {
+  private List<BannerRequest> requests;
+
+  public List<BannerRequest> getRequests() {
+    return requests;
+  }
+
+  public void setRequests(List<BannerRequest> requests) {
+    this.requests = requests;
+  }
+}


### PR DESCRIPTION
**테스트 결과**
```
k6-load-test      | running (0m46.0s), 01/10 VUs, 24 complete and 0 interrupted iterations
k6-load-test      | default ↓ [ 100% ] 10 VUs  30s                                                                                                                                      
k6-load-test      | 
k6-load-test      |      ✓ 배너 bulk API 응답 상태가 201인가?
k6-load-test      |      ✓ 응답에 배열 데이터가 포함되어 있는가?                                                                                                                        
k6-load-test      | 
k6-load-test      |      checks.........................: 100.00% 50 out of 50                                                                                                          
k6-load-test      |      data_received..................: 29 kB   630 B/s                                                                                                               
k6-load-test      |      data_sent......................: 14 kB   305 B/s
k6-load-test      |      http_req_blocked...............: avg=446.59µs min=5.26µs   med=14.55µs max=1.66ms   p(90)=1.21ms   p(95)=1.39ms                                                
k6-load-test      |      http_req_connecting............: avg=85.94µs  min=0s       med=0s      max=798.62µs p(90)=207.93µs p(95)=237.02µs                                              
k6-load-test      |      http_req_duration..............: avg=14.25s   min=4.35s    med=11.39s  max=42.17s   p(90)=23.24s   p(95)=25.98s  
k6-load-test      |        { expected_response:true }...: avg=14.25s   min=4.35s    med=11.39s  max=42.17s   p(90)=23.24s   p(95)=25.98s                                                
k6-load-test      |      http_req_failed................: 0.00%   0 out of 25
k6-load-test      |      http_req_receiving.............: avg=1.15ms   min=611.46µs med=1.12ms  max=2.06ms   p(90)=1.56ms   p(95)=1.74ms                                                
k6-load-test      |      http_req_sending...............: avg=105.75µs min=30.65µs  med=83.99µs max=290.2µs  p(90)=197.56µs p(95)=270.21µs                                              
k6-load-test      |      http_req_tls_handshaking.......: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
k6-load-test      |      http_req_waiting...............: avg=14.24s   min=4.35s    med=11.38s  max=42.17s   p(90)=23.24s   p(95)=25.98s                                                
k6-load-test      |      http_reqs......................: 25      0.538865/s                                                                                                            
k6-load-test      |      iteration_duration.............: avg=15.25s   min=5.35s    med=12.39s  max=43.18s   p(90)=24.25s   p(95)=26.99s  
k6-load-test      |      iterations.....................: 25      0.538865/s                                                                                                            
k6-load-test      |      vus............................: 1       min=1        max=10                                                                                                   
k6-load-test      |      vus_max........................: 10      min=10       max=10
k6-load-test      |                                                                                                                                                                     
k6-load-test      | 
k6-load-test      | running (0m46.4s), 00/10 VUs, 25 complete and 0 interrupted iterations                                                                                              
k6-load-test      | default ✓ [ 100% ] 10 VUs  30s                                                                                                                                      
k6-load-test exited with code 0
```
**개요**
기존에는 GPT 호출을 CompletableFuture.join()으로 순차적으로 처리하고 있었습니다. 이 구조는 비동기 호출의 병렬성이 충분히 활용되지 않아, 대량 요청 시 성능 저하가 발생하는 문제가 있었습니다.
이번 PR에서는 thenApply()와 CompletableFuture.allOf()을 통해 병렬 처리 구조를 적용하여 응답 속도 및 처리량을 개선하였습니다.

**주요 변경 사항**

1. BannerService

- createMultipleBanners() 메서드를 비동기 병렬 처리 구조로 개선

- 각 요청마다 generateAdTextsAsync() 호출 후 thenApply()로 Banner 생성

- CompletableFuture.allOf()로 모든 비동기 작업 완료까지 대기

2. BannerController

- /api/v1/banners/bulk 경로로 다건 배너 생성 API 추가

**성능 개선 비교 (k6 부하 테스트 기준)**
![image](https://github.com/user-attachments/assets/28ad02bb-4baf-4dad-bc5d-f513950ee529)

### 성능 저하 의심 및 병목 분석 계획
**개선 후에도 특정 요청에서 평균 응답 시간이 예상보다 높게 측정되는 현상이 발견되었습니다.
정확한 병목 지점을 식별하기 위해 Prometheus + Grafana 기반의 애플리케이션 모니터링을 도입할 예정입니다.
이를 통해 CPU 사용률, 쓰레드 풀, I/O 지연, 외부 API 호출 시간(GPT) 등을 정밀하게 분석할 계획입니다.**

### 향후 개선 방향
- ThreadPoolTaskExecutor 설정값 조정 및 스레드 풀 사이징

- GPT 응답 캐싱 적용 (@Cacheable)

- GPT API Timeout 및 예외 대응 고도화

- 외부 API 호출 모니터링 및 경고 설정