### PR TITLE
feat : ThreadPoolTaskExecutor 도입을 통한 GPT 비동기 호출 성능 최적화

### DIFF
--- a/TecheerPicture/build.gradle
+++ b/TecheerPicture/build.gradle
@@ -58,7 +58,6 @@ dependencies {
 	implementation 'org.json:json:20210307'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'com.squareup.okhttp3:okhttp:4.11.0' //외부 API 호출 OkHttp 사용
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/TecheerPicture/docker-compose.yml
+++ b/TecheerPicture/docker-compose.yml
@@ -147,3 +147,6 @@
   networks:
     techeer-network:
       name: techeer-network
+
+
+

--- a/TecheerPicture/prometheus/prometheus.yml
+++ b/TecheerPicture/prometheus/prometheus.yml
@@ -6,3 +6,4 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['spring-boot-app:8080']
+

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/external/GPTService.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/external/GPTService.java
@@ -1,10 +1,9 @@
 package com.techeerpicture.TecheerPicture.Banner.external;
 
-import org.springframework.scheduling.annotation.Async;
+import com.techeerpicture.TecheerPicture.Banner.util.GeneratedTexts;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -12,32 +11,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import com.techeerpicture.TecheerPicture.Banner.util.GeneratedTexts;
-/**
- * GPTService
- *
- * OpenAI GPT API를 사용하여 광고 문구를 생성하는 서비스 클래스입니다.
- * 입력된 제품 정보를 바탕으로 GPT를 호출하여 광고 문구를 생성하고, 이를 처리하여 반환합니다.
- */
 @Service
 public class GPTService {
 
   @Value("${GPT_API}")
-  private String apiKey; // OpenAI API 키를 저장하는 필드
+  private String apiKey;
 
-  /**
-   * 광고 문구를 생성하는 메서드
-   *
-   * @param itemName       제품 이름
-   * @param itemConcept    제품 컨셉
-   * @param itemCategory   제품 카테고리
-   * @param addInformation 추가 정보
-   * @return GeneratedTexts 생성된 광고 문구를 담은 객체
-   */
   public GeneratedTexts generateAdTexts(String itemName, String itemConcept, String itemCategory, String addInformation, String imageUrl) {
     String apiUrl = "https://api.openai.com/v1/chat/completions";
 
-    // GPT 요청 프롬프트 작성
     String prompt = String.format(
         "다음 제품 정보를 바탕으로 광고 문구를 생성해주세요:\n" +
             "제품 이름: '%s'\n" +
@@ -54,10 +36,9 @@ public class GPTService {
             "- 세트 2:\n" +
             "  메인 문장: [maintext2]\n" +
             "  서브 문장: [servtext2]",
-        itemName, itemConcept, itemCategory, addInformation,imageUrl
+        itemName, itemConcept, itemCategory, addInformation, imageUrl
     );
 
-    // 요청 본문 생성
     Map<String, Object> requestBody = Map.of(
         "model", "gpt-4o",
         "messages", List.of(
@@ -68,43 +49,37 @@ public class GPTService {
         "temperature", 0.7
     );
 
-    // 요청 헤더 설정
     HttpHeaders headers = new HttpHeaders();
     headers.set("Authorization", "Bearer " + apiKey);
     headers.set("Content-Type", "application/json");
 
-    // 요청 엔티티 생성
     HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
     RestTemplate restTemplate = new RestTemplate();
 
     try {
-      // OpenAI API 호출
       ResponseEntity<Map> responseEntity = restTemplate.postForEntity(apiUrl, entity, Map.class);
       Map<String, Object> responseBody = responseEntity.getBody();
 
-      // 응답 검증
       if (responseBody == null || !responseBody.containsKey("choices")) {
         throw new RuntimeException("OpenAI 응답이 올바르지 않습니다.");
       }
 
-      // 응답 데이터 추출
       List<Map<String, Object>> choices = (List<Map<String, Object>>) responseBody.get("choices");
       Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
       String generatedText = (String) message.get("content");
 
-      // 생성된 텍스트 검증
       if (generatedText == null || generatedText.isEmpty()) {
         throw new RuntimeException("OpenAI로부터 생성된 텍스트가 비어 있습니다.");
       }
 
-      // 생성된 텍스트 파싱
       return parseGeneratedText(generatedText);
 
     } catch (Exception e) {
       throw new RuntimeException("GPT 호출 실패: " + e.getMessage(), e);
     }
   }
-  @Async
+
+  @Async("gptExecutor")
   public CompletableFuture<GeneratedTexts> generateAdTextsAsync(
       String itemName, String itemConcept, String itemCategory,
       String addInformation, String imageUrl
@@ -112,16 +87,10 @@ public class GPTService {
     GeneratedTexts texts = generateAdTexts(itemName, itemConcept, itemCategory, addInformation, imageUrl);
     return CompletableFuture.completedFuture(texts);
   }
-  /**
-   * 생성된 텍스트를 파싱하여 광고 문구를 추출하는 메서드
-   *
-   * @param generatedText 생성된 GPT 응답 텍스트
-   * @return GeneratedTexts 추출된 광고 문구를 담은 객체
-   */
+
   private GeneratedTexts parseGeneratedText(String generatedText) {
     String[] lines = generatedText.split("\n");
 
-    // 세트 1과 세트 2의 메인 및 서브 문장 추출
     String mainText1 = removeQuotes(findText(lines, "- 세트 1:", "메인 문장:", "서브 문장:"));
     String servText1 = removeQuotes(findText(lines, "- 세트 1:", "서브 문장:", "- 세트 2:"));
     String mainText2 = removeQuotes(findText(lines, "- 세트 2:", "메인 문장:", "서브 문장:"));
@@ -130,21 +99,12 @@ public class GPTService {
     return new GeneratedTexts(mainText1, servText1, mainText2, servText2);
   }
 
-  /**
-   * 특정 텍스트 블록에서 마커를 사용하여 텍스트를 추출하는 메서드
-   *
-   * @param lines      텍스트 라인 배열
-   * @param setMarker  세트를 구분하는 마커
-   * @param startMarker 시작 마커
-   * @param endMarker   끝 마커 (null이면 라인 끝까지 추출)
-   * @return 추출된 텍스트
-   */
   private String findText(String[] lines, String setMarker, String startMarker, String endMarker) {
     boolean isInSet = false;
 
     for (String line : lines) {
       if (setMarker != null && line.contains(setMarker)) {
-        isInSet = true; // 해당 세트에 진입
+        isInSet = true;
       }
 
       if (isInSet && line.contains(startMarker)) {
@@ -159,14 +119,8 @@ public class GPTService {
     return "";
   }
 
-  /**
-   * 문자열의 양끝에 있는 따옴표를 제거하는 메서드
-   *
-   * @param text 입력 문자열
-   * @return 따옴표가 제거된 문자열
-   */
   private String removeQuotes(String text) {
     if (text == null) return "";
-    return text.replaceAll("^\"|\"$", ""); // 앞뒤의 "를 제거
+    return text.replaceAll("^\"|\"$", "");
   }
 }

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Config/AsyncConfig.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.techeerpicture.TecheerPicture.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  @Bean("gptExecutor")
+  public Executor gptExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    int coreCount = Runtime.getRuntime().availableProcessors();
+
+    executor.setCorePoolSize(coreCount);
+    executor.setMaxPoolSize(coreCount * 2);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("GPT-Async-");
+    executor.initialize();
+    return executor;
+  }
+}


### PR DESCRIPTION
<h3>작업 목적</h3>
<ul>
  <li>광고 문구 생성 API에서 비동기 GPT 호출의 안정성과 성능을 향상시키기 위함</li>
  <li>기본 ForkJoinPool 사용의 한계를 극복하고, 스레드 자원 관리를 명확하게 하기 위함</li>
</ul>

<hr/>

<h3>주요 변경 사항</h3>
<ul>
  <li><code>AsyncConfig</code> 클래스에 <code>ThreadPoolTaskExecutor</code> Bean 등록</li>
  <li>CPU 코어 수 기반으로 동적으로 스레드 풀 크기 설정</li>
  <ul>
    <li><code>corePoolSize: N</code>, <code>maxPoolSize: N * 2</code>, <code>queueCapacity: 100</code></li>
  </ul>
  <li>스레드 이름 접두어: <code>GPT-Async-</code></li>
  <li><code>GPTService</code>에서 <code>@Async("gptExecutor")</code> 명시</li>
  <li><code>generateAdTextsAsync</code> 메서드가 등록한 스레드 풀에서 실행되도록 변경</li>
  <li><code>BannerService</code>의 비동기 로직 변경</li>
  <li><code>.thenApplyAsync(..., gptExecutor)</code>를 명시하여 병렬 작업이 지정된 풀에서 실행되도록 구성</li>
</ul>

<hr/>

<h3>기대 효과</h3>
<ul>
  <li>스레드 수를 명시적으로 제한하여 시스템 자원 과다 사용 방지</li>
  <li>병렬 요청 시에도 안정적인 성능 유지</li>
  <li>스레드 이름으로 디버깅 및 모니터링 용이</li>
</ul>
