### PR TITLE
feat: Banner 전체 조회 기능

### DIFF
--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/controller/BannerController.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/controller/BannerController.java
@@ -98,6 +98,30 @@ public class BannerController {
     }
   }
 
+  @GetMapping("/image/{imageId}")
+  @Operation(summary = "이미지 ID로 배너 조회", description = "이미지 ID로 연결된 배너 목록을 조회합니다. (N+1 발생 예시)")
+  public ResponseEntity<Map<String, Object>> getBannersByImageId(@PathVariable Long imageId) {
+    List<Banner> banners = bannerService.getBannersByImageId(imageId);
+
+    List<Map<String, Object>> dataList = banners.stream().map(banner -> {
+      Map<String, Object> data = new LinkedHashMap<>();
+      data.put("id", banner.getId());
+      data.put("image_id", banner.getImage().getId());
+      data.put("maintext", banner.getMainText1());
+      data.put("servetext", banner.getServText1());
+      data.put("maintext2", banner.getMainText2());
+      data.put("servetext2", banner.getServText2());
+      return data;
+    }).collect(Collectors.toList());
+
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("code", 200);
+    response.put("message", "이미지 ID로 배너 조회 성공");
+    response.put("data", dataList);
+
+    return ResponseEntity.ok(response);
+  }
+
   @PutMapping("/{bannerId}")
   @Operation(summary = "광고 텍스트 수정", description = "배너 ID를 통해 광고 텍스트를 수정합니다.")
   public ResponseEntity<Map<String, Object>> updateBanner(

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/entity/Banner.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/entity/Banner.java
@@ -14,7 +14,7 @@ public class Banner {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @OneToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "image_id", referencedColumnName = "id", nullable = false)
   private Image image;
 

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/repository/BannerRepository.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/repository/BannerRepository.java
@@ -2,7 +2,7 @@ package com.techeerpicture.TecheerPicture.Banner.repository;
 
 import com.techeerpicture.TecheerPicture.Banner.entity.Banner;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 /**
  * BannerRepository
  *
@@ -15,4 +15,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  *   - Long: 엔티티의 기본 키 데이터 타입
  */
 public interface BannerRepository extends JpaRepository<Banner, Long> {
+  List<Banner> findAllByImage_Id(Long imageId);
 }

--- a/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/service/BannerService.java
+++ b/TecheerPicture/src/main/java/com/techeerpicture/TecheerPicture/Banner/service/BannerService.java
@@ -122,4 +122,14 @@ public class BannerService {
 
     return bannerRepository.save(banner);
   }
+
+  @Transactional(readOnly = true)
+  public List<Banner> getBannersByImageId(Long imageId) {
+    List<Banner> banners = bannerRepository.findAllByImage_Id(imageId);
+    for (Banner banner : banners) {
+      banner.getImage().getImageUrl();
+    }
+
+    return banners;
+  }
 }


### PR DESCRIPTION
### 기능 추가: Banner 전체 조회 기능
- /api/v1/banners 엔드포인트를 통해 모든 배너 데이터를 조회할 수 있는 기능을 추가했습니다.
- 기존에 존재하던 개별 조회, 생성, 수정, 삭제 API와 함께 전체 조회 기능이 완성되었습니다.

### 테스트 및 모니터링 결과 공유
- 전체 조회 기능을 개발한 뒤, 실제 배포 환경에서 Grafana 기반의 시스템 자원 모니터링을 진행했습니다.
- 아래는 /api/v1/banners 호출 직후의 CPU 사용률 / Load Average / GC 활동 / 커넥션 수 변화를 확인한 그래프입니다.

![image](https://github.com/user-attachments/assets/c89926e3-c622-4351-bc68-4ffbeb4c3a8c)
![image](https://github.com/user-attachments/assets/8a8112d2-9269-4944-9a03-9c2956b12e60)
![image](https://github.com/user-attachments/assets/d83ecdd2-3c1a-441f-84bf-061f8b4c4869)

### 문제점
- 특정 시간대 전체 배너 조회 요청 직후, GC 활동 증가, Load Average 상승, DB 커넥션 활성화 증가 현상이 확인되었습니다.
- 이를 통해JPA의 N+1 문제를 고민해볼 수 있습니다. Banner ↔ Image 간 연관 관계에서 @ManyToOne(fetch = LAZY) 설정이 영향을 줄 수 있다고 판단됩니다.