### PR TITLE
feat: N+1 쿼리 이슈 분석 및 Hibernate SQL 로그 설정 추가

### DIFF
--- a/TecheerPicture/src/main/resources/application.yml
+++ b/TecheerPicture/src/main/resources/application.yml
@@ -1,0 +1,83 @@
+spring:
+  application:
+    name: TecheerPicture
+
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+  main:
+    allow-bean-definition-overriding: true
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+    serialization:
+      indent_output: true
+
+cloud:
+  aws:
+    credentials:
+      accessKey: ${AWS_S3_ACCESSKEY}
+      secretKey: ${AWS_S3_SECRETKEY}
+    s3:
+      region:
+        static: ${AWS_S3_REGION}
+      bucket: techeer-picture-bucket
+
+server:
+  port: 8080
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+
+IG_APP_ID: ${IG_APP_ID}
+IG_ID: ${IG_ID}
+ACCESS_TOKEN: ${ACCESS_TOKEN}
+INSTAGRAM_APP_SECRET: ${INSTAGRAM_APP_SECRET}
+INSTAGRAM_REDIRECT_URI: ${INSTAGRAM_REDIRECT_URI}
+INSTAGRAM_AUTH_URL: ${INSTAGRAM_AUTH_URL}
+INSTAGRAM_TOKEN_URL: ${INSTAGRAM_TOKEN_URL}
+INSTAGRAM_LONG_LIVED_TOKEN_URL: ${INSTAGRAM_LONG_LIVED_TOKEN_URL}
+INSTAGRAM_REFRESH_TOKEN_URL: ${INSTAGRAM_REFRESH_TOKEN_URL}
+
+fal:
+  api:
+    key: ${FAL_KEY}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    prometheus:
+      enabled: true
+    health:
+      show-details: always
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE


### PR DESCRIPTION
### 문제 상황
프로젝트에서 전체 배너 조회 기능을 개발한 뒤, 약 900개의 배너가 특정 image_id에 연결되어 있는 상황에서 API를 호출하면 응답 시간이 길어지고 리소스 사용량이 급증하는 현상이 있었습니다.
이를 검증하기 위해 Prometheus + Grafana 기반의 모니터링을 통해 확인하였고, 실제 API 호출에 대한 시스템 리소스 사용 현황과 쿼리 로그를 분석했습니다.

### 결과 및 분석
![image](https://github.com/user-attachments/assets/b68b53c0-9abe-4de6-b45a-fc0bbf3fc98a)
![image](https://github.com/user-attachments/assets/25afe4bd-37a4-4e67-ae29-494f4bddcc92)

- banners 테이블에서 image_id 조건으로 배너를 조회한 후, 각각의 배너가 참조하고 있는 Image 엔티티를 다시 개별적으로 조회하는 쿼리가 발생했습니다.
- 이는 JPA의 @ManyToOne(fetch = FetchType.LAZY) 설정으로 인해 지연 로딩이 발생하며, Banner 900건에 대해 각각 Image 쿼리 900건이 실행되는 N+1 문제입니다.

### 모니터링 결
![image](https://github.com/user-attachments/assets/79288cde-8dc2-4409-bba8-453f033a2914)
![image](https://github.com/user-attachments/assets/51e6c0b7-3273-4315-be93-5d9eaededeef)
![image](https://github.com/user-attachments/assets/daa193d9-d0f4-40b6-af81-d05b27abccc5)

- GC 시간 증가, 힙 메모리 순간적 상승
- 응답 지연
- Thread 사용 급증 → 실제로 시스템 부하가 증가하는 양상을 시각적으로 확인했습니다.

### 해결방안
- fetch join을 통한 N+1 해결